### PR TITLE
correct soon to be deprecated podspec usage; update cordova/node req to match

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
 - echo yes | android update sdk --filter platform-tools --no-ui --force > /dev/null
 - echo yes | android update sdk --filter android-28 --no-ui --force > /dev/null
 - echo yes | android update sdk --filter build-tools-28.0.3 --all --no-ui --force > /dev/null
+- pod repo update
 install:
 - npm install -g cordova
 - npm install -g ionic

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "com.testfairy.cordova-plugin",
   "version": "2.48.0",
   "description": "TestFairy SDK plugin for Cordova",
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "cordova": {
     "id": "com.testfairy.cordova-plugin",
     "platforms": [

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,7 +4,7 @@
     <description>TestFairy SDK plugin for Cordova</description>
     <license>Apache 2.0 License</license>
     <engines>
-        <engine name="cordova" version=">=3.2.0" />
+        <engine name="cordova" version=">=9.0.0" />
     </engines>
 
     <js-module src="www/testfairy.js" name="TestFairy">
@@ -22,7 +22,14 @@
         </config-file>
         <header-file src="src/ios/CDVTestFairy.h" />
         <source-file src="src/ios/CDVTestFairy.m" />
-        <framework src="TestFairy" type="podspec" spec="1.28.7" />
+        <podspec>
+            <config>
+                <source url="https://cdn.cocoapods.org/"/>
+            </config>
+            <pods use-frameworks="true">
+                <pod name="TestFairy" spec="1.28.7" />
+            </pods>
+        </podspec>
     </platform>
     <platform name="android">
         <source-file src="src/android/CDVTestFairy.java" target-dir="src/com/testfairy" />


### PR DESCRIPTION
1. updates the podspec tag in plugin.xml to prevent a cordova deprecation warning
2. update cordova/node versions to prevent issues
3. update pod repo in travis to ensure its always fresh

Closes #32 